### PR TITLE
Update mw cleaner.bat

### DIFF
--- a/mw cleaner.bat
+++ b/mw cleaner.bat
@@ -53,9 +53,9 @@ echo Cleaning...
 timeout 2
 cls
 
-rem Kill any running instances of Agent.exe or Battle.net.exe
-taskkill /IM Agent.exe /F 2>nul
-taskkill /IM Battle.net.exe /F 2>nul
+taskkill /IM "Agent.exe" /F /T 2>nul
+taskkill /IM "Battle.net.exe" /F /T 2>nul
+
 
 rem Delete various files and directories
 del "D:\Program Files (x86)\Call of Duty Modern Warfare\main\data0.dcache" 2>nul


### PR DESCRIPTION
In this version, the /T option has been added to the taskkill command. This option terminates the process and all of its child processes, which can be useful if the process has spawned any child processes that need to be terminated as well.

It's important to note that forcibly terminating processes can potentially cause issues with the system or other running applications, so it should be used with caution.



